### PR TITLE
Bugfix/new-quest-card

### DIFF
--- a/src/components/Cards/CardList.jsx
+++ b/src/components/Cards/CardList.jsx
@@ -25,35 +25,42 @@ const CardList = () => {
       <PageLoader>Loading...</PageLoader>;
     } else if (isSuccess) {
       return (
-        <List>
-          {createNew && <NewQuestCard />}
-          {cards.map((c) => (
-            <Card
-              key={c._id}
-              id={c._id}
-              title={c.title}
-              difficulty={c.difficulty}
-              category={c.category}
-              date={c.date}
-              time={c.time}
-              type={c.type}
-            />
-          ))}
-        </List>
+        <>
+          <List>
+            {createNew && <NewQuestCard />}
+            {cards.map((c) => (
+              <Card
+                key={c._id}
+                id={c._id}
+                title={c.title}
+                difficulty={c.difficulty}
+                category={c.category}
+                date={c.date}
+                time={c.time}
+                type={c.type}
+              />
+            ))}
+          </List>
+          <NewTaskBtn onClick={handleClick} />
+        </>
       );
     } else if (!isSuccess) {
-      return <p>No quests on the board.</p>;
+      return (
+        <>
+          {createNew ? <NewQuestCard /> : <p>No quests on the board.</p>}
+          <NewTaskBtn onClick={handleClick} />
+        </>
+      );
     } else if (isError) {
       return isError && <p>Error: {error}</p>;
     }
   };
 
-  let questListContent = checkContent();
+  let cardListContent = checkContent();
 
   return (
     <>
-      {questListContent}
-      <NewTaskBtn onClick={handleClick} />
+      {cardListContent}
     </>
   );
 };

--- a/src/components/NewQuestCard/NewQuestCard.jsx
+++ b/src/components/NewQuestCard/NewQuestCard.jsx
@@ -43,13 +43,15 @@ const NewQuestCard = () => {
   const handleOpenDifficultyMenu = (event) => {
     setAnchorDifficulty(event.currentTarget);
   };
+
   const handleOpenCategoryMenu = (event) => {
     setAnchorCategory(event.currentTarget);
   };
+
   const handleOnChange = (event) => {
     setTitle(event.currentTarget.value);
-    console.log(title);
   };
+
   const handleSelectedDifficulty = (e) => {
     e.currentTarget.innerText === ""
       ? setDifficult(difficult)
@@ -57,6 +59,7 @@ const NewQuestCard = () => {
 
     setAnchorDifficulty(null);
   };
+
   const handleSelectedCategory = (e) => {
     e.currentTarget.innerText === ""
       ? setCategory(category)
@@ -78,8 +81,13 @@ const NewQuestCard = () => {
       time: time,
       type: "Task",
     };
-    console.log(body);
-    title ? createCard(body) : setError("Titile missing");
+
+    const validPost = (body) => {
+      createCard(body);
+      setTitle("");
+    };
+
+    title ? validPost(body) : setError("Titile missing");
   };
 
   const difficulties = ["Easy", "Normal", "Hard"];
@@ -136,6 +144,7 @@ const NewQuestCard = () => {
       <InputWrapper>
         <label htmlFor="create-new-quest">CREATE NEW QUEST</label>
         <input
+          value={title}
           id="create-new-quest"
           type="text"
           autoFocus

--- a/src/components/NewTaskBtn/NewTaskBtn.jsx
+++ b/src/components/NewTaskBtn/NewTaskBtn.jsx
@@ -1,25 +1,10 @@
 import React from "react";
 import { Div } from "./NewTaskBtn.styled";
-import { useCreateCardMutation } from "../../redux/slices/questifyAPI";
-import { tomorrow } from "../../utils/datetime";
 
-const NewTaskBtn = () => {
-  const [addTask] = useCreateCardMutation();
-
-  const btnClick = () => {
-    addTask({
-      title: "Take out the trash",
-      difficulty: "Easy",
-      category: "Stuff",
-      date: tomorrow,
-      time: "20:32",
-      type: "Task",
-    });
-  };
-
+const NewTaskBtn = ({ onClick }) => {
   return (
     <Div>
-      <button onClick={btnClick}>
+      <button onClick={onClick}>
         <svg
           width="16"
           height="16"


### PR DESCRIPTION
Poprawiłem bugi związane z renderowaniem kart i dodawaniem nowego Quest'a. Teraz powinno wszystko być OK.

Propozycje dalszych czynności:
- Podczas edycji jeżeli użytkownik kliknie na ikonę gwiazdki to karta dodawania Questu zmienia się na dodawanie Challenge
- Podczas edycji nowego Quest'u / Challenge'u jeżeli użytkownik się rozmyśli czyli kliknie X lub obok karty to znika okno edycji (opcjonalnie po wciśnięciu klawisza Esc)
- Dodanie możliwości usuwania istniejącego Quest'u / Challenge'u